### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/simplegravatar/templatetags/simplegravatar.py
+++ b/simplegravatar/templatetags/simplegravatar.py
@@ -1,7 +1,13 @@
-import urllib, hashlib
+import sys
+import hashlib
+
 from django import template
 from django.conf import settings
 
+if sys.version_info[0] == 2:
+    from urllib import urlencode
+else:
+    from urllib.parse import urlencode
 
 register = template.Library()
 
@@ -11,24 +17,24 @@ def show_gravatar(email, size=None, ssl=False):
     '''
     An inclusion tag that inserts gravatar image.
     '''
-    
+
     size = size or getattr(settings, 'SIMPLEGRAVATAR_SIZE', 80)
     rating = getattr(settings, 'SIMPLEGRAVATAR_RATING', 'g')
     default = getattr(settings, 'SIMPLEGRAVATAR_DEFAULT', '')
     ssl = getattr(settings, 'SIMPLEGRAVATAR_SECURE', False)
-     
+
     gravatar_base = 'http://www.gravatar.com/avatar'
     if ssl:
         gravatar_base = 'https://secure.gravatar.com/avatar'
 
     url = "%s/%s.jpg?%s" % (gravatar_base,
-                            hashlib.md5(email).hexdigest(),
-                            urllib.urlencode({
+                            hashlib.md5(email.encode('utf-8')).hexdigest(),
+                            urlencode({
                                 'size': str(size),
                                 'rating': rating,
                                 'default': default,
                             }))
-    
+
     return {
         'gravatar': {
             'url': url, 'size': size
@@ -42,5 +48,3 @@ def show_gravatar_secure(email, size=None):
     An inclusion tag that inserts gravatar image (over https).
     '''
     return show_gravatar(email, size, True)
-    
-    


### PR DESCRIPTION
- _urllib.urlencode_ on Python3 is _urllib.parse.urlencode_ 
- _hashlib_ want unicode before hash
